### PR TITLE
ビルドシステムを更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # clangd関連
 *cache*/
+
+# ユーザプリセットを除外
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.31)
 
 # このプロジェクトの概要を設定する
 project(challenger

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,16 +7,6 @@ project(challenger
     DESCRIPTION "SDL3向けのC++ラッパ."
 )
 
-# ビルド周りの設定
-option(BUILD_SHARED_LIBS "Build shared libraries." OFF)
-option(CMAKE_BUILD_TYPE "Build type." Release)
-option(BUILD_EXAMPLE "Build example programs" OFF)
-
-# CMAKE_EXPORT_COMPILE_COMMANDSの既定値を設定する
-if ((NOT (DEFINED $ENV{CMAKE_EXPORT_COMPILE_COMMANDS})) AND (DEFINED CMAKE_EXPORT_COMPILE_COMMANDS))
-  set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
-endif()
-
 # C++コンパイラに渡すオプションを設定する
 add_compile_options(-Wall $<$<CONFIG:Debug>:-g3>)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (NOT TARGET SDL3::Headers OR NOT TARGET SDL3::SDL3)
     FetchContent_Declare(
         sdl
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG preview-3.1.3
+        GIT_TAG release-3.2.22
     )
     FetchContent_MakeAvailable(sdl)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+    "version": 10,
+    "cmakeMinimumRequired": {
+        "major": 3, "minor": 31, "patch": 0
+    },
+    "$comment": "CMakeの最小バージョンはUbuntuの最新LSTにて利用可能なバイナリのバージョンに合わせる．",
+    "configurePresets": [{
+        "name": "default",
+        "displayName": "Default config",
+        "binaryDir": "${sourceDir}/build",
+        "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "Release",
+            "BUILD_SHARED_LIBS": "OFF", 
+            "BUILD_EXAMPLE": "OFF"
+        }
+    }],
+    "buildPresets": [{
+        "name": "default", "configurePreset": "default"
+    }],
+    "workflowPresets": [{
+        "name": "default","steps": [
+            {"type": "configure", "name": "default"},
+            {"type": "build", "name": "default"}
+        ]
+    }]
+}


### PR DESCRIPTION
* `CMake 4.0.0`対応の更新
* コンパイル時の設定を`CMakePresets.json`に移動．
  + 今後は下記の順に`cmake`を利用すること．
    - 設定: `cmake --preset <preset name> (--fresh)`
    - ビルド: `cmake --build --preset <preset name>`
